### PR TITLE
[PARAMETERS]feat: add sort_by_size param to request

### DIFF
--- a/aio/aio-proxy/aio_proxy/request/search_params_model.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_model.py
@@ -72,6 +72,7 @@ class SearchParams(BaseModel):
     minimal: bool | None = False
     include: list | None = None
     include_admin: list | None = None
+    sort_by_size: bool | None = None
 
     # Field Validators (involve one field at a time)
     @field_validator(
@@ -211,6 +212,7 @@ class SearchParams(BaseModel):
         "minimal",
         "est_societe_mission",
         "est_siae",
+        "sort_by_size",
         mode="before",
     )
     def convert_str_to_bool(cls, boolean: str, info) -> bool:
@@ -330,6 +332,7 @@ class SearchParams(BaseModel):
             "minimal",
             "include",
             "include_admin",
+            "sort_by_size",
         ]
 
         all_fields_are_null_except_excluded = check_params_are_none_except_excluded(
@@ -354,6 +357,7 @@ class SearchParams(BaseModel):
             "minimal",
             "include",
             "include_admin",
+            "sort_by_size",
         ]
 
         all_fields_are_null_except_excluded = check_params_are_none_except_excluded(

--- a/aio/aio-proxy/aio_proxy/search/helpers/helpers.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers/helpers.py
@@ -77,3 +77,7 @@ def compute_doc_id(page_etablissements):
         int: The calculated page ID.
     """
     return page_etablissements * 100
+
+
+def sort_search_by_company_size(es_search_builder):
+    return es_search_builder.search_params.sort_by_size is True

--- a/aio/aio-proxy/aio_proxy/search/queries/text.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/text.py
@@ -243,6 +243,36 @@ def sort_by_size_text_query(terms: str, matching_size: int):
                         "min_score": 4,
                     }
                 },
+                {
+                    "function_score": {
+                        "query": {
+                            "match": {
+                                "unite_legale.liste_dirigeants": {
+                                    "query": terms,
+                                    "operator": "AND",
+                                    "boost": 10,
+                                    "_name": "partial match liste dirigeants",
+                                }
+                            }
+                        },
+                        "field_value_factor": min_multiplier,
+                    }
+                },
+                {
+                    "function_score": {
+                        "query": {
+                            "match": {
+                                "unite_legale.liste_elus": {
+                                    "query": terms,
+                                    "operator": "AND",
+                                    "boost": 10,
+                                    "_name": "partial match liste élus",
+                                }
+                            }
+                        },
+                        "field_value_factor": min_multiplier,
+                    }
+                },
             ],
         }
     }

--- a/aio/aio-proxy/aio_proxy/search/queries/text.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/text.py
@@ -6,11 +6,11 @@ def build_text_query(terms: str, matching_size: int, sort_by_size: bool = False)
 
 
 def sort_by_size_text_query(terms: str, matching_size: int):
-    multiplier = "unite_legale.code_categorie_entreprise"
+    multiplier = "unite_legale.facteur_taille_entreprise"
     min_multiplier = {
         "field": multiplier,
         "factor": 1,
-        "modifier": "square",
+        "modifier": "log2p",
         "missing": 0,
     }
     mid_multiplier = {
@@ -104,7 +104,7 @@ def sort_by_size_text_query(terms: str, matching_size: int):
                                 "_name": "match all champs denomination",
                             }
                         },
-                        "field_value_factor": max_multiplier,
+                        "field_value_factor": mid_multiplier,
                     }
                 },
                 {

--- a/aio/aio-proxy/aio_proxy/search/queries/text.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/text.py
@@ -250,7 +250,7 @@ def sort_by_size_text_query(terms: str, matching_size: int):
 
 
 def sort_by_nombre_etablissement_query(terms: str, matching_size: int):
-    multiplier = "nombre_etablissements_ouverts"
+    multiplier = "unite_legale.nombre_etablissements_ouverts"
     min_multiplier = {
         "field": multiplier,
         "factor": 1,

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -22,6 +22,7 @@ from aio_proxy.search.helpers.exclude_etablissements import (
 from aio_proxy.search.helpers.helpers import (
     get_doc_id_from_page,
     should_get_doc_by_id,
+    sort_search_by_company_size,
 )
 from aio_proxy.search.parsers.siren import is_siren
 from aio_proxy.search.parsers.siret import is_siret
@@ -114,6 +115,9 @@ def build_es_search_text_query(es_search_builder):
             es_search_builder.search_params
         )
 
+        # Check if results should be based on company size
+        sort_by_size = sort_search_by_company_size(es_search_builder)
+
         if etablissement_filter_used:
             # Filters applied on établissements, 1st application of filters
             # before text search to make sure the text_query (on unite légale) is
@@ -140,6 +144,7 @@ def build_es_search_text_query(es_search_builder):
                 text_query = build_text_query(
                     terms=query_terms,
                     matching_size=es_search_builder.search_params.matching_size,
+                    sort_by_size=sort_by_size,
                 )
                 text_query_with_filters = (
                     add_nested_etablissements_filters_to_text_query(
@@ -168,6 +173,7 @@ def build_es_search_text_query(es_search_builder):
             text_query = build_text_query(
                 terms=query_terms,
                 matching_size=es_search_builder.search_params.matching_size,
+                sort_by_size=sort_by_size,
             )
             es_search_builder.es_search_client = (
                 es_search_builder.es_search_client.query(Q(text_query))


### PR DESCRIPTION
Closes #340

A new search option has been added, introducing changes to the search algorithm that prioritize larger companies in the search results.

The field used to weight the search results is `facteur_taille_entreprise`, calculated as the product of two fields: `code_categorie_entreprise` and `nombre_etablissements_ouverts`.

To emphasize larger companies, a new parameter, `sort_by_size`, has been introduced. This parameter accepts a boolean value of True or False.