### PR TITLE
[FIX]Add redoc url redirect `/docs to /docs/`

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ import yaml
 from elasticapm.contrib.starlette import ElasticAPM, make_apm_client
 from elasticsearch_dsl import connections
 from fastapi import FastAPI, Request
+from fastapi.responses import RedirectResponse
 
 from app.config import (
     APM_CONFIG,
@@ -32,7 +33,7 @@ app = FastAPI(
     title="API Recherche d'entreprises",
     version="1.0.0",
     docs_url=None,
-    redoc_url="/docs",
+    redoc_url="/docs/",
 )
 
 
@@ -60,6 +61,12 @@ app.include_router(admin.router)
 
 # Add exception handlers
 add_exception_handlers(app)
+
+
+# Redirect /docs to /docs/
+@app.get("/docs", include_in_schema=False)
+async def docs_redirect():
+    return RedirectResponse(url="/docs/")
 
 
 # Catch-all route for 404 errors

--- a/app/main.py
+++ b/app/main.py
@@ -32,7 +32,7 @@ app = FastAPI(
     title="API Recherche d'entreprises",
     version="1.0.0",
     docs_url=None,
-    redoc_url="/docs/",
+    redoc_url="/docs",
 )
 
 


### PR DESCRIPTION
This is by default the behaviour in fastAPI, however the last exception handler by default returns a 404 for unknown endpoints.