### PR TITLE
[SEARCH]fix: remove stop words from dirigeant before match query

### DIFF
--- a/app/elastic/queries/person.py
+++ b/app/elastic/queries/person.py
@@ -81,7 +81,7 @@ def search_person(
         # Prénoms
         prenoms_person = search_params.dict().get(param_prenom, None)
         if prenoms_person:
-            # Remove stop words from the name
+            # Remove stop words
             prenoms_person_filtered = remove_stop_words(prenoms_person)
             # Same logic as "nom" is used for "prenoms"
             for prenom in prenoms_person_filtered.split(" "):


### PR DESCRIPTION
closes https://github.com/annuaire-entreprises-data-gouv-fr/search-api/issues/374

The filters for `nom_personne` and `prenoms_personne` currently use two types of queries. The first is a `match` query, which ensures that each word in the query is present in the results. The second is a `match_phrase` query, which boosts the score for exact matches, ensuring those results are prioritized.

However, when handling names like **"BERNARD DE SAINT AFFRIQUE"**, which contain French stop words (e.g., **"DE"**), the `match` query fails. This happens because the custom analyzer used during indexing removes stop words like "DE", meaning no match is found for them. While the `match_phrase` still correctly identifies exact matches, the `must` clause of the `match` query returns no results due to the missing stop word.

To fix this issue, this PR introduces a change that removes stop words (like "DE") from `nom_personne` and `prenoms_personne` before adding them to the `match` query. However, the complete list of words, including stop words, is still passed to the `match_phrase` query to ensure exact matches are boosted as before.

Additionally, this change removes the need to apply the entire analyzer to the query, which unnecessarily complicates the search and sometimes returns incorrect results. By removing stop words manually, we ensure the search is simpler and more accurate.