### PR TITLE
[FIX]Raise error if radius is nan

### DIFF
--- a/app/controller/search_params_model.py
+++ b/app/controller/search_params_model.py
@@ -94,7 +94,7 @@ class SearchParams(BaseModel):
     @field_validator("radius", "lat", "lon", mode="before")
     def cast_as_float(cls, value: str, info) -> float:
         try:
-            if value == "nan":
+            if value.lower() == "nan":
                 raise ValueError
             float(value)
         except ValueError:


### PR DESCRIPTION
An HTTP 500 error is generated when the "radius" field is not a number.

Example:

http://recherche-entreprises.api.gouv.fr/near_point?minimal=true&include=siege,matching_etablissements&lat=47.92139251962604&long=-1.9418394282147005&radius=NaN&per_page=25&page=1

**Fix**: Add a check to validate if "radius" lower case  is not a number (`nan`) and raise a `ValueError` in such cases. This will ensure the API properly handles invalid inputs and returns a more appropriate error message instead of an HTTP 500.