### PR TITLE
[BUG]fix: add search type validation for certain params

### DIFF
--- a/app/controller/search_params_builder.py
+++ b/app/controller/search_params_builder.py
@@ -22,7 +22,7 @@ class SearchParamsBuilder:
 
     @staticmethod
     def map_request_parameters(request):
-        # Extract all query parameters from the request
+        """Extract and map request parameters to their internal field names."""
         request_params = request.query_params
         mapped_params = {}
         for param, param_value in request_params.items():
@@ -37,15 +37,16 @@ class SearchParamsBuilder:
         return mapped_params
 
     @staticmethod
-    def get_search_params(request):
+    def get_search_params(request, search_type):
         """Map the request parameters to match the Pydantic model's field name."""
         mapped_params = SearchParamsBuilder.map_request_parameters(request)
+        mapped_params["search_type"] = search_type
         params = SearchParams(**mapped_params)
         return params
 
     @staticmethod
     def extract_params(request, search_type):
         if search_type in (SearchType.TEXT, SearchType.GEO):
-            return SearchParamsBuilder.get_search_params(request)
+            return SearchParamsBuilder.get_search_params(request, search_type)
         else:
             raise ValueError("Unknown search type!!!")

--- a/app/controller/search_params_model.py
+++ b/app/controller/search_params_model.py
@@ -362,6 +362,7 @@ class SearchParams(BaseModel):
         """
         # List of parameters to exclude from the check
         excluded_fields = [
+            "search_type",
             "page",
             "per_page",
             "matching_size",

--- a/app/controller/search_params_model.py
+++ b/app/controller/search_params_model.py
@@ -335,6 +335,7 @@ class SearchParams(BaseModel):
         """
         excluded_fields = [
             "search_type",
+            "radius",
             "page",
             "page_etablissements",
             "per_page",
@@ -363,6 +364,7 @@ class SearchParams(BaseModel):
         # List of parameters to exclude from the check
         excluded_fields = [
             "search_type",
+            "radius",
             "page",
             "per_page",
             "matching_size",
@@ -405,9 +407,7 @@ class SearchParams(BaseModel):
 
         elif self.search_type == SearchType.TEXT:
             # For text search, don't allow lat/lon/radius
-            if any(
-                [self.lat is not None, self.lon is not None, self.radius is not None]
-            ):
+            if any([self.lat is not None, self.lon is not None]):
                 raise InvalidParamError(
                     "Les paramètres 'lat', 'long' et 'radius' ne sont autorisés "
                     "que pour une recherche géographique."

--- a/app/controller/search_params_model.py
+++ b/app/controller/search_params_model.py
@@ -335,7 +335,6 @@ class SearchParams(BaseModel):
         """
         excluded_fields = [
             "search_type",
-            "radius",
             "page",
             "page_etablissements",
             "per_page",
@@ -407,7 +406,9 @@ class SearchParams(BaseModel):
 
         elif self.search_type == SearchType.TEXT:
             # For text search, don't allow lat/lon/radius
-            if any([self.lat is not None, self.lon is not None]):
+            if any(
+                [self.lat is not None, self.lon is not None, self.radius is not None]
+            ):
                 raise InvalidParamError(
                     "Les paramètres 'lat', 'long' et 'radius' ne sont autorisés "
                     "que pour une recherche géographique."

--- a/app/controller/search_params_model.py
+++ b/app/controller/search_params_model.py
@@ -246,10 +246,10 @@ class SearchParams(BaseModel):
                 )
 
         elif self.search_type == SearchType.TEXT:
-            # For text search, don't allow lat/lon/radius
+            # For text search, don't allow lat/lon
             if any([self.lat is not None, self.lon is not None]):
                 raise InvalidParamError(
-                    "Les paramètres 'lat', 'long' et 'radius' ne sont autorisés "
+                    "Les paramètres 'lat', 'long' ne sont autorisés "
                     "que pour une recherche géographique."
                 )
         return self

--- a/app/tests/e2e_tests/test_api.py
+++ b/app/tests/e2e_tests/test_api.py
@@ -791,6 +791,6 @@ def test_search_type_validation(api_response_tester):
     api_response_tester.assert_api_response_code_400(path)
     response = api_response_tester.get_api_response(path)
     assert response.json()["erreur"] == (
-        "Les paramètres 'lat', 'long' et 'radius' ne sont autorisés "
+        "Les paramètres 'lat', 'long' ne sont autorisés "
         "que pour une recherche géographique."
     )

--- a/app/tests/e2e_tests/test_api.py
+++ b/app/tests/e2e_tests/test_api.py
@@ -618,8 +618,9 @@ def test_near_point_without_lat(api_response_tester):
     path = "near_point?long=67"
     api_response_tester.assert_api_response_code_400(path)
     response = api_response_tester.get_api_response(path)
-    assert (
-        response.json()["erreur"] == "Veuillez indiquer une latitude entre -90° et 90°."
+    assert response.json()["erreur"] == (
+        "Les paramètres 'lat' et 'long' sont obligatoires pour une "
+        "recherche géographique."
     )
 
 
@@ -764,3 +765,32 @@ def test_ul_sans_siege(api_response_tester):
     api_response_tester.assert_api_response_code_200(path)
     api_response_tester.test_number_of_results(path, 1)
     api_response_tester.test_field_value(path, 0, "siege", {})
+
+
+def test_search_type_validation(api_response_tester):
+    """Test validation rules for different search types"""
+    # Test GEO search requires lat/lon
+    path = "near_point?radius=5"
+    api_response_tester.assert_api_response_code_400(path)
+    response = api_response_tester.get_api_response(path)
+    assert response.json()["erreur"] == (
+        "Les paramètres 'lat' et 'long' sont obligatoires pour une "
+        "recherche géographique."
+    )
+
+    # Test GEO search doesn't allow terms
+    path = "near_point?lat=48.86&long=2.35&q=test"
+    api_response_tester.assert_api_response_code_400(path)
+    response = api_response_tester.get_api_response(path)
+    assert response.json()["erreur"] == (
+        "Le paramètre 'terms' n'est pas autorisé pour une recherche géographique."
+    )
+
+    # Test TEXT search doesn't allow geo params
+    path = "search?q=test&lat=48.86&long=2.35"
+    api_response_tester.assert_api_response_code_400(path)
+    response = api_response_tester.get_api_response(path)
+    assert response.json()["erreur"] == (
+        "Les paramètres 'lat', 'long' et 'radius' ne sont autorisés "
+        "que pour une recherche géographique."
+    )


### PR DESCRIPTION
![Screenshot 2025-01-16 at 17 06 15](https://github.com/user-attachments/assets/1dffa56b-ae24-4688-a83a-bb3958f03aeb)
In Sentry, an error occurred while using the `near_point?radius=10` query. This was because the `lat` and `long` parameters were made mandatory when either of them was provided, but they were not set as obligatory for the endpoint itself. 

Another issue identified was the possibility of scraping data by combining the `lat`, `long`, and `radius` parameters with the `page` parameter in the `/search` endpoint. The API treated these parameters as valid inputs without restricting their use, allowing users to theoretically navigate through pages. This PR resolves these issues by clearly defining which primary parameters are required for each endpoint.