### PR TITLE
[BUG][SENTRY]Add type validation to financial params

### DIFF
--- a/app/controller/search_params_model.py
+++ b/app/controller/search_params_model.py
@@ -82,7 +82,15 @@ class SearchParams(BaseModel):
 
     # Field Validators (involve one field at a time)
     @field_validator(
-        "page", "page_etablissements", "per_page", "matching_size", mode="before"
+        "page",
+        "page_etablissements",
+        "per_page",
+        "matching_size",
+        "ca_min",
+        "ca_max",
+        "resultat_net_min",
+        "resultat_net_max",
+        mode="before",
     )
     def cast_as_integer(cls, value: str, info) -> int:
         try:

--- a/app/tests/e2e_tests/test_api.py
+++ b/app/tests/e2e_tests/test_api.py
@@ -794,3 +794,13 @@ def test_search_type_validation(api_response_tester):
         "Les paramètres 'lat', 'long' ne sont autorisés "
         "que pour une recherche géographique."
     )
+
+
+def test_invalid_ca_min_returns_400(api_response_tester):
+    """Test that providing a non-integer ca_min returns a 400 error"""
+    path = "search?ca_min=1234 GH"
+    api_response_tester.assert_api_response_code_400(path)
+    response = api_response_tester.get_api_response(path)
+    assert response.json()["erreur"] == (
+        "Veuillez indiquer un paramètre `ca_min` entier."
+    )


### PR DESCRIPTION
When given a string value for param `ca_min` for example, it returns a 500 instead of Bad Request.