### PR TITLE
fix: add favicon endpoint to handle browser requests

### DIFF
--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Request
+from fastapi.responses import Response
 
 from app.service.build_api_response import build_api_response
 from app.service.search_type import SearchType
@@ -20,3 +21,10 @@ async def near_point_endpoint(request: Request):
         request,
         search_type=SearchType.GEO,
     )
+
+
+# Handle browser favicon requests to prevent 404 errors in logs
+# Returns 204 No Content since this is an API service without a favicon
+@router.get("/favicon.ico")
+async def favicon():
+    return Response(status_code=204)

--- a/app/tests/e2e_tests/response_tester.py
+++ b/app/tests/e2e_tests/response_tester.py
@@ -3,6 +3,7 @@ from requests.adapters import HTTPAdapter, Retry
 
 ok_status_code = 200
 client_error_status_code = 400
+no_content_status_code = 204
 min_total_results = 10
 min_total_results_filters = 1000
 
@@ -52,6 +53,12 @@ class APIResponseTester:
         assert response_status_code == client_error_status_code, (
             f"API response code is " f"{response_status_code}, expected 400."
         )
+
+    def assert_api_response_code_204(self, path):
+        response_status_code = self.get_api_response_code(path)
+        assert (
+            response_status_code == no_content_status_code
+        ), f"API response code is {response_status_code}, expected 204."
 
     def test_field_value(self, path, result_number, field_name, expected_value):
         response = self.get_api_response(path)

--- a/app/tests/e2e_tests/test_api.py
+++ b/app/tests/e2e_tests/test_api.py
@@ -804,3 +804,11 @@ def test_invalid_ca_min_returns_400(api_response_tester):
     assert response.json()["erreur"] == (
         "Veuillez indiquer un paramètre `ca_min` entier."
     )
+
+
+def test_favicon(api_response_tester):
+    """
+    Test that favicon.ico endpoint returns 204 No Content
+    """
+    path = "favicon.ico"
+    api_response_tester.assert_api_response_code_204(path)


### PR DESCRIPTION
Added a simple endpoint that returns a 204 No Content response for `/favicon.ico` requests. This is a minimal implementation that:
- Eliminates 404 errors from logs
- Doesn't waste resources serving an actual favicon (since this is an API service)
- Properly handles the browser requests without affecting API functionality

### Testing
- Verified that browser requests for favicon.ico now return 204 instead of 404
- Confirmed logs no longer show 404 errors for favicon requests

Very cryptic warning in Sentry, might be related to this. We'll see 👀 
![Screenshot 2025-01-17 at 13 51 50](https://github.com/user-attachments/assets/b6e480af-2203-43d3-bf6a-2b9fc6be76f7)
