### PR TITLE
feat(search algo): decrease threshold score for matching etab

### DIFF
--- a/app/elastic/queries/text.py
+++ b/app/elastic/queries/text.py
@@ -515,7 +515,7 @@ def sort_by_nombre_etablissement_query(terms: str, matching_size: int):
                             }
                         },
                         "field_value_factor": min_multiplier,
-                        "min_score": 3,
+                        "min_score": 2,
                     }
                 },
                 {


### PR DESCRIPTION
[USER FEEDBACK]

This addresses an issue where the query `/search?q=maccity&code_postal=31000` returns an empty list, while `/search?q=maccity `correctly retrieves an unite legale that has an associated etablissement in the 31000 postal code. The reason for the discrepancy lies in the scoring: the text query's score was 2.08, which fell below the threshold of 3, resulting in no results being returned.

To resolve this, the PR lowers the threshold from 3 to 2. While this change may potentially introduce the risk of including more results when querying the API, the thresholds were originally determined through trial and error rather than a rigorous benchmark. Additionally, the test set used at the time has since become outdated.