### PR TITLE
[OPS]deps(build): upgrade to Elasticsearch 8.17

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,11 +1,11 @@
 PyYAML==5.3.1
-elasticsearch==7.17.0
-elasticsearch_dsl==7.4.0
+elasticsearch==8.17.1
+elasticsearch_dsl==8.17.1
+elastic-apm==6.23.0
 requests==2.31.0
 sentry-sdk==2.13.0
 python-dotenv==1.0.1
 pytest==7.2.1
-elastic-apm==6.14.0
 redis==4.1.1
 httpx==0.28.1
 pydantic==2.10.5


### PR DESCRIPTION
related to https://github.com/annuaire-entreprises-data-gouv-fr/search-api/issues/121
All E2E tests pass for this update 🤞 