### PR TITLE
🔒 [DataPrivacy]fix(nd): show denimination fields for etablissements nd

### DIFF
--- a/app/service/formatters/non_diffusible.py
+++ b/app/service/formatters/non_diffusible.py
@@ -73,7 +73,7 @@ def hide_non_diffusible_unite_legale(result_formatted, est_personne_morale_insee
         for etablissement in result_formatted.get(etab_list_key, []):
             # For all pther etablissements, we mask denomination fields
             hide_non_diffusible_etablissement_fields(
-                etablissement, hide_denomination=True
+                etablissement, hide_denomination=not est_personne_morale_insee
             )
 
     return result_formatted

--- a/app/tests/e2e_tests/test_api.py
+++ b/app/tests/e2e_tests/test_api.py
@@ -933,7 +933,7 @@ def test_nd_pm_sans_nom_commercial(api_response_tester):
     for etab_list_key in ("matching_etablissements", "etablissements"):
         for etab in ul.get(etab_list_key, []):
             if "nom_commercial" in etab:
-                assert etab["nom_commercial"] == "[NON-DIFFUSIBLE]"
+                assert etab["nom_commercial"] != "[NON-DIFFUSIBLE]"
 
 
 def test_nd_pm_avec_nom_commercial(api_response_tester):
@@ -955,7 +955,7 @@ def test_nd_pm_avec_nom_commercial(api_response_tester):
     for etab_list_key in ("matching_etablissements", "etablissements"):
         for etab in ul.get(etab_list_key, []):
             if "nom_commercial" in etab:
-                assert etab["nom_commercial"] == "[NON-DIFFUSIBLE]"
+                assert etab["nom_commercial"] != "[NON-DIFFUSIBLE]"
 
 
 def test_nd_pm_avec_sigle(api_response_tester):
@@ -977,4 +977,26 @@ def test_nd_pm_avec_sigle(api_response_tester):
     for etab_list_key in ("matching_etablissements", "etablissements"):
         for etab in ul.get(etab_list_key, []):
             if "nom_commercial" in etab:
-                assert etab["nom_commercial"] == "[NON-DIFFUSIBLE]"
+                assert etab["nom_commercial"] != "[NON-DIFFUSIBLE]"
+
+
+def test_secondary_etab_nd_pm_avec_nom_commercial(api_response_tester):
+    path = "search?q=94793126700027"
+    response = api_response_tester.get_api_response(path)
+    api_response_tester.assert_api_response_code_200(path)
+    ul = response.json()["results"][0]
+
+    # UL: sigle must be masked; nom_complet should not be masked
+    assert ul.get("sigle") == "[NON-DIFFUSIBLE]"
+    assert ul["nom_complet"] != "[NON-DIFFUSIBLE]"
+
+    # Siege: denomination should not be masked for PM if present
+    siege = ul.get("siege", {})
+    if "nom_commercial" in siege and siege["nom_commercial"] is not None:
+        assert siege["nom_commercial"] != "[NON-DIFFUSIBLE]"
+
+    # Other etablissements: denomination masked if present
+    for etab_list_key in ("matching_etablissements", "etablissements"):
+        for etab in ul.get(etab_list_key, []):
+            if "nom_commercial" in etab:
+                assert etab["nom_commercial"] != "[NON-DIFFUSIBLE]"


### PR DESCRIPTION
related to #567 
@hacherix you were right, l'Insee treats le siege and the other etablissements the same way according to their API.