### PR TITLE
build: upgrade dependencies

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,9 +3,9 @@ elasticsearch==9.3.0
 fastapi[standard]==0.141.1
 orjson==3.11.6
 pydantic==2.13.2
-pydantic-settings==2.14.2
-pytest==9.1.1
-PyYAML==6.0.2
+pydantic-settings==2.15.0
 redis==8.1.0
 requests==2.34.1
-sentry-sdk==2.66.0
+sentry-sdk==2.68.0
+PyYAML==6.0.2
+pytest==9.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,15 @@ authors = [
 readme = "README.md"
 license-files = ["LICENSE"]
 dependencies = [
-    "elasticsearch==9.3.0",
-    "requests==2.34.1",
     "elastic-apm==6.26.2",
-    "sentry-sdk==2.66.0",
-    "redis==8.1.0",
-    "pydantic==2.13.2",
+    "elasticsearch==9.3.0",
     "fastapi[standard]==0.141.1",
     "orjson==3.11.6",
-    "pydantic-settings==2.14.2",
+    "pydantic==2.13.2",
+    "pydantic-settings==2.15.0",
+    "redis==8.1.0",
+    "requests==2.34.1",
+    "sentry-sdk==2.68.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Dépendances réordonnées pour que le pyproject soit similaire aux requirements.
pydantic-settings==2.14.2->2.15.0
sentry-sdk==2.68.0->2.68.0